### PR TITLE
Grammar and spelling fixes

### DIFF
--- a/abstract.tex
+++ b/abstract.tex
@@ -1,5 +1,5 @@
 This article explores the use of artificial intelligence in board games, focusing
-on the advancements of AlphaGo\cite{AlphaGoAlgorithm} and AlphaGo Zero\cite{AlphaGoZero}. 
+on the advancements of AlphaGo \cite{AlphaGoAlgorithm} and AlphaGo Zero \cite{AlphaGoZero}. 
 AlphaGo marked a milestone in AI by defeating professional Go players using a 
 combination of supervised learning and neural networks for policy and value estimation. 
 AlphaGo Zero simplified the architecture by integrating policy and value evaluation 

--- a/engine_architecture.tex
+++ b/engine_architecture.tex
@@ -19,14 +19,14 @@ This section will focus on the architecture of this engine and how the communica
 % Opisanie architektury silnika, sposobu komunikacji między komponentami, a także za co one odpowiadają.
 
 In this section, the project of game architecture will be discussed.
-Figure \ref{fig:SystemArchitecture} shows a diagram of the whole system as implemented by the team.
+Figure \ref{fig:SystemArchitecture} shows a diagram of the entire system as implemented by the team.
 Computations related to processing games are performed on a CPU,
 while agents should be trained on a GPU.
 
 \begin{figure*}
 	\centering
 	\scalebox{.48}{\input{figures/arch.tex}}
-	\caption{Diagram of the system's architecture}
+	\caption{Diagram of the system's architecture.}
 	\label{fig:SystemArchitecture}
 \end{figure*}
 
@@ -48,16 +48,16 @@ It should optimise communication by reducing data transfer between CPU and GPU.
 
 The GameEngine (and Visualiser) is implemented in Go, while the agent and TrainingSupervisor
 are implemented in Python. The use of Go for the engine was meant to allow for better performance of
-the rule engine but it means that the TrainingSupervisor cannot communicate with it directly.
+the rule engine, but it means that the TrainingSupervisor cannot communicate with it directly.
 To solve this, the team used the gopy project \cite{gopy} to automatically generate
 Python bindings \cite{LanguageBindings} for the Go package. This leads to a larger overhead than
-using manually-written CPython extension would but this has been considered acceptable as most of
+using manually-written CPython extension would, but this has been considered acceptable as most of
 the CPU-bound work happens in the GameEngine itself, not at the communication layer.
 
 \subsection{Components of a solution}
 % Opisanie elementów z jakich się składa rozgrywka m.in.: kafelki i ich elementy, gracze, a także uwzględnione rozszerzenia gry Carcassonne.
 
-The game Carcassone is played by placing tiles \cite{CarcassoneRules}. Each tile is represented by a set of features on it. All features are defined by their type, such as road, city, field or monastery, a modifier that modifies the calculation process, and the sides which indicate on which edges the feature is present. In this project, there is only one modifier used - the shield. The engine was designed to accommodate game extensions.
+The game Carcassonne is played by placing tiles \cite{CarcassoneRules}. Each tile is represented by a set of features on it. All features are defined by their type, such as road, city, field or monastery, a modifier that modifies the calculation process, and the sides which indicate on which edges the feature is present. In this project, there is only one modifier used - the shield. The engine was designed to accommodate game extensions.
 
 A feature's side is a byte-sized value, in which each bit defines whether the feature is present on a specific half of the tile's edge as shown on Figure \ref{fig:SIDES}. Features such as roads, are represented by a whole edge formed by combining two sides e.g., the TopLeft and TopRight sides.
 \begin{figure}
@@ -89,14 +89,15 @@ A feature's side is a byte-sized value, in which each bit defines whether the fe
         \node [rotate=270] at (-2.8, 1.5) {LeftTop};
         \node [rotate=270] at (-2.8, -1.5) {LeftBottom};
     \end{tikzpicture}
-    \caption{Side representation} \label{fig:SIDES}
+    \caption{Side representation.}
+    \label{fig:SIDES}
 \end{figure}
 
 The tiles described do not contain information about their position or meeple placement. This information is located in the PlacedTile struct. The board is represented as a tile set containing tiles used in the game, for verification whether the tile a player wants to place is legal. Moreover, it contains a slice of placed tiles in the same order as the tile set. Additionally, the board includes a city manager used for merging cities, scoring and checking for legal meeple placements in the cities.
 
 A single game is represented by a board, a shuffled deck of tiles, and players partaking in it. Each player knows their score and the number of meeples of each type available to them.
 
-Our solution has been designed to be modifiable by adding extensions to the game. Generalizations, such as meeple type or feature type, allow for the easy implementation of new potential features, e.g. rivers.
+Our solution has been designed to be modifiable by adding extensions to the game. Generalizations, such as meeple type or feature type, allow for the easy implementation of new potential features, e.g.\ rivers.
 
 \subsection{Game flow}
 % Opisanie wykonywanych akcji podejmowanych przez silnik gry: wylosowanie kafelka ze stosu, wyliczenie legalnych ułożeń kafelka, wybór położenia i wyliczanie punktacji za jego położenie.
@@ -107,13 +108,13 @@ Figure \ref{fig:GameFlow} shows a state diagram of the game.
 \begin{figure*}
 	\centering
 	\scalebox{.42}{\input{figures/state-diagram.tex}}
-	\caption{Carcassonne's state diagram}
+	\caption{Carcassonne's state diagram.}
 	\label{fig:GameFlow}
 \end{figure*}
 
 Before the game can start, a few actions need to be performed as part of the \textbf{Preparation} stage:
 \begin{itemize}
-	\item putting a start tile on the board,
+	\item Putting a start tile on the board,
 	\item generating a stack of all (remaining) tiles in random order,
 	\item setting the figure count for each player to $7$,
 	\item resetting the scores of all players to $0$,
@@ -129,9 +130,9 @@ placed somewhere on the board which it then includes as part of the state passed
 When no tiles are left on the stack, the engine proceeds to the \textbf{Final scoring} stage
 (described later).
 
-Once the agent knows the tile it needs to place, it needs to choose \textbf{Tile placement} and,
+Once the agent knows the tile it needs to place, it needs to select \textbf{Tile placement} and,
 if it has any figures, \textbf{Figure placement}. In the implementation, this is performed
-as a single action - the agent has to choose both the position/rotation of the tile and the feature
+as a single action - the agent has to pick both the position/rotation of the tile and the feature
 to put a meeple on (if any) which it then sends as input to play the turn.
 The engine allows the agent to ask for valid tile placements as well as valid features to
 place meeple on for the given tile, taking into account whether that feature (which can spread
@@ -184,7 +185,7 @@ a specific feature type contributes to the overall time of turn processing.
 During the measurement, a test for a specific feature places tiles consisting of
 only that specific feature. For each feature, two testing strategies were used:
 \begin{itemize}
-	\item a test with a single game where each tile is placed on the right of the previous one,
+	\item A test with a single game where each tile is placed on the right of the previous one,
           resulting in a long row of tiles consisting of that feature,
     \item a test with many shorter (in terms of the tile count) games,
           each ending with a short row of tiles consisting of that feature.
@@ -211,15 +212,15 @@ To mitigate this, we worked on improving the engine's performance.
 
 We found and implemented a few ideas for enhancing the efficiency of the system:
 \begin{itemize}
-	\item allowing to compare tile and placed tile types without needing to convert one to another,
+	\item Allowing to compare tile and placed tile types without needing to convert one to another,
     \item updating the null logger implementation to be a full no-op,
     \item allowing the engine to receive requests from the agent on multiple threads,
-    \item changing the tile representation to simple integers of a constant size (i.e. no slices)
+    \item changing the tile representation to simple integers of a constant size (i.e.\ no slices)
           that can be operated on with bitwise operations,
     \item holding just the shield count rather than the exact positions of shields in cities,
     \item decreasing the size of enum types such as feature type and shield flag to a single byte,
     \item decreasing the size of X and Y position coordinates to single-byte integers.
 \end{itemize}
 Some of the above solutions resulted in promising improvements,
-while others offered smaller speedups or, in some cases, had the opposite effect.
+while others offered smaller speed-ups or, in some cases, had the opposite effect.
 Overall, the performance gains were not enough to allow for use in agent training.

--- a/main.tex
+++ b/main.tex
@@ -40,27 +40,17 @@
 \input{sections/results.tex}
 
 \begin{thebibliography}{00}
-\bibitem{CarcassoneRules}
-K. Wrede, Carcassonne rules, Z-Man Games, 2016.
-% https://images.zmangames.com/filer\_public/d5/20/d5208d61-8583-478b-a06d-b49fc9cd7aaa/zm7810\_carcassonne\_rules.pdf
-
-\bibitem{GolangPipeline}
-S. Ajmani, Go Concurrency Patterns: Pipelines and cancellation, The Go Blog, 2014: \url{https://go.dev/blog/pipelines}
-
 \bibitem{AlphaGoAlgorithm}
 Silver, D., Schrittwieser, J., Simonyan, K. et al.\ Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). \url{https://doi.org/10.1038/nature24270}
+
+\bibitem{AlphaGoZero}
+Silver, D., Schrittwieser, J., Simonyan, K. et al. Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). \url{https://doi.org/10.1038/nature24270}
 
 \bibitem{AlphaGoBlog}
 Google DeepMind. AlphaGo. \url{https://deepmind.google/research/breakthroughs/alphago/} (accessed: 28.05.2024)
 
 \bibitem{AlphaGoZeroBlog}
 David Silver and Demis Hassabis. Alpha{G}o {Z}ero: {S}tarting from scratch. \url{https://deepmind.google/discover/blog/alphago-zero-starting-from-scratch/} (accessed: 28.05.2024)
-
-\bibitem{AlphaZero}
- Silver, David; Hubert, Thomas; Schrittwieser, Julian; Antonoglou, Ioannis; Lai, Matthew; Guez, Arthur; Lanctot, Marc; Sifre, Laurent; Kumaran, Dharshan; Graepel, Thore; Lillicrap, Timothy; Simonyan, Karen; Hassabis, Demis (December 5, 2017). "Mastering Chess and Shogi by Self-Play with a General Reinforcement Learning Algorithm". arXiv:1712.01815 [cs.AI].
-
-\bibitem{AlphaGoZero}
-Silver, D., Schrittwieser, J., Simonyan, K. et al. Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). \url{https://doi.org/10.1038/nature24270}
 
 \bibitem{MasterThesisCarcassonne}
 C. Heyden, Implementing a computer player for Carcassonne, Master's thesis, Department of Knowledge Engineering, Maastricht University, 2009,
@@ -73,5 +63,15 @@ The go-python Authors, gopy project: \url{https://github.com/go-python/gopy}
 \bibitem{LanguageBindings}
 Wikipedia contributors, Language binding, Wikipedia, The Free Encyclopedia, 2024:
 \url{https://en.wikipedia.org/wiki/Language\_binding}
+
+\bibitem{CarcassoneRules}
+K. Wrede, Carcassonne rules, Z-Man Games, 2016.
+% https://images.zmangames.com/filer\_public/d5/20/d5208d61-8583-478b-a06d-b49fc9cd7aaa/zm7810\_carcassonne\_rules.pdf
+
+\bibitem{GolangPipeline}
+S. Ajmani, Go Concurrency Patterns: Pipelines and cancellation, The Go Blog, 2014: \url{https://go.dev/blog/pipelines}
+
+\bibitem{AlphaZero}
+Silver, David; Hubert, Thomas; Schrittwieser, Julian; Antonoglou, Ioannis; Lai, Matthew; Guez, Arthur; Lanctot, Marc; Sifre, Laurent; Kumaran, Dharshan; Graepel, Thore; Lillicrap, Timothy; Simonyan, Karen; Hassabis, Demis (December 5, 2017). "Mastering Chess and Shogi by Self-Play with a General Reinforcement Learning Algorithm". arXiv:1712.01815 [cs.AI].
 \end{thebibliography}
 \end{document}

--- a/main.tex
+++ b/main.tex
@@ -2,6 +2,7 @@
 \usepackage{authblk}
 \usepackage{pslatex, graphicx, amssymb, amsmath}
 \usepackage{tikz}
+\usepackage[hidelinks]{hyperref}
 %%%% Redefine abstract environment
 \def\abstract{
 \typeout{Abstract}
@@ -18,7 +19,7 @@
 \author[1]{Krzysztof Pisarski}
 \author[2]{Piotr Mironowicz}
 \affil[1]{Faculty of Electronics, Telecommunications and Informatics, Gdańsk University of Technology, 80-233 Gdańsk, Poland}
-\affil[2]{Department of Algorithms and System Modeling, Faculty of Electronics, Telecommunications and Informatics, Gdańsk University of Technology, 80-233 Gdańsk, Poland}
+\affil[2]{Department of Algorithms and System Modelling, Faculty of Electronics, Telecommunications and Informatics, Gdańsk University of Technology, 80-233 Gdańsk, Poland}
 
 
 \maketitle
@@ -44,22 +45,22 @@ K. Wrede, Carcassonne rules, Z-Man Games, 2016.
 % https://images.zmangames.com/filer\_public/d5/20/d5208d61-8583-478b-a06d-b49fc9cd7aaa/zm7810\_carcassonne\_rules.pdf
 
 \bibitem{GolangPipeline}
-S. Ajmani, Go Concurrency Patterns: Pipelines and cancellation, The Go Blog, 2014: https://go.dev/blog/pipelines
+S. Ajmani, Go Concurrency Patterns: Pipelines and cancellation, The Go Blog, 2014: \url{https://go.dev/blog/pipelines}
 
 \bibitem{AlphaGoAlgorithm}
-Silver, D., Schrittwieser, J., Simonyan, K. et al. Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). https://doi.org/10.1038/nature24270
+Silver, D., Schrittwieser, J., Simonyan, K. et al.\ Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). \url{https://doi.org/10.1038/nature24270}
 
 \bibitem{AlphaGoBlog}
-Google DeepMind. AlphaGo. https://deepmind.google/research/breakthroughs/alphago/ (accessed: 28.05.2024)
+Google DeepMind. AlphaGo. \url{https://deepmind.google/research/breakthroughs/alphago/} (accessed: 28.05.2024)
 
 \bibitem{AlphaGoZeroBlog}
-David Silver and Demis Hassabis. Alpha{G}o {Z}ero: {S}tarting from scratch. https://deepmind.google/discover/blog/alphago-zero-starting-from-scratch/ (accessed: 28.05.2024)
+David Silver and Demis Hassabis. Alpha{G}o {Z}ero: {S}tarting from scratch. \url{https://deepmind.google/discover/blog/alphago-zero-starting-from-scratch/} (accessed: 28.05.2024)
 
 \bibitem{AlphaZero}
  Silver, David; Hubert, Thomas; Schrittwieser, Julian; Antonoglou, Ioannis; Lai, Matthew; Guez, Arthur; Lanctot, Marc; Sifre, Laurent; Kumaran, Dharshan; Graepel, Thore; Lillicrap, Timothy; Simonyan, Karen; Hassabis, Demis (December 5, 2017). "Mastering Chess and Shogi by Self-Play with a General Reinforcement Learning Algorithm". arXiv:1712.01815 [cs.AI].
 
 \bibitem{AlphaGoZero}
-Silver, D., Schrittwieser, J., Simonyan, K. et al. Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). https://doi.org/10.1038/nature24270
+Silver, D., Schrittwieser, J., Simonyan, K. et al. Mastering the game of Go without human knowledge. Nature 550, 354–359 (2017). \url{https://doi.org/10.1038/nature24270}
 
 \bibitem{MasterThesisCarcassonne}
 C. Heyden, Implementing a computer player for Carcassonne, Master's thesis, Department of Knowledge Engineering, Maastricht University, 2009,
@@ -67,19 +68,10 @@ pages 13-14.
 % https://project.dke.maastrichtuniversity.nl/games/files/msc/MasterThesisCarcassonne.pdf
 
 \bibitem{gopy}
-The go-python Authors, gopy project: https://github.com/go-python/gopy
+The go-python Authors, gopy project: \url{https://github.com/go-python/gopy}
 
 \bibitem{LanguageBindings}
 Wikipedia contributors, Language binding, Wikipedia, The Free Encyclopedia, 2024:
-https://en.wikipedia.org/wiki/Language\_binding
-
-\bibitem{samplejournal}
-N. Author, Title of paper, Title of the journal, volume, year,
-pages.
-\bibitem{samplebook}
-N. Author, Title of book, Publisher, place and
-year.
-\bibitem{samplechapter}
-N. Author, Title of paper, In: Title of monograph, name(s) of editor, publisher, place and year, pages.
+\url{https://en.wikipedia.org/wiki/Language\_binding}
 \end{thebibliography}
 \end{document}

--- a/sections/agent_architecture.tex
+++ b/sections/agent_architecture.tex
@@ -12,9 +12,10 @@ the underlying game engine. Tree is populated iteratively until one of the
 postconditions is reached (either time elapsed or maximum number of iterations). 
 During the expansion phase in the MCTS algorithm, the Upper Confidence Bound (UCB) 
 is used to select the most promising child nodes. This formula is used to obtain 
-the balance between exploration of less-visited nodes and the ones that proved to yield highest rewards.
+the balance between exploration of less-visited nodes and the ones that proved to
+yield the highest rewards.
 
-The core of the decision making is a combination of two evaluation metrics. 
+The core of the decision-making is a combination of two evaluation metrics. 
 One is calculated during selection (policy) and the other during expansion (value). 
 As an input they take a serialized game state represented as a binary mask and both 
 return respective evaluation scores reduced by discount factor, which is used to 
@@ -28,8 +29,8 @@ the agent to be submitted as an actual move to the engine.
 
 This whole structure was inspired by the implementation of AlphaGo Zero, 
 and it allows for an efficient and universal training process, since 
-it is well suited for solving complex decision-making tasks in games like Carccassone. 
+it is well suited for solving complex decision-making tasks in games like Carcassonne. 
 Based on this architecture, the team prepared agents using different 
-tactics (e.g. greedy method and random selection) which later will be used to 
+tactics (e.g.\ greedy method and random selection) which later will be used to 
 measure performance of a neural network agent and provide a baseline for comparison.
 

--- a/sections/experiment.tex
+++ b/sections/experiment.tex
@@ -7,6 +7,5 @@ both against human and computer random players. The criterion of success was
 measured as an average points scored by the agent.
 During the research, the team conducted a series of simulations and real-time experiments. 
 The first method was used to run games between computer agents, while the second 
-- between the agent and human players.  All of the games were stored as logs 
+- between the agent and human players.  All the games were stored as logs 
 which allowed us to easily reconstruct the games and strategies.
-

--- a/sections/introduction.tex
+++ b/sections/introduction.tex
@@ -10,7 +10,7 @@ only to master this game but also to devise innovative moves unknown to humans b
 
 Since then, we have noticed rapid development in this area. A crucial milestone was
 the creation of AlphaGo Zero which, in contrast to its predecessors, used only reinforcement
-learning during training and yet managed to outperform all of the older versions in only forty
+learning during training and yet managed to outperform all the older versions in only forty
 days \cite{AlphaGoZeroBlog}. That opened up opportunities for AI to master other games like chess 
 or shogi.
 

--- a/sections/results.tex
+++ b/sections/results.tex
@@ -1,6 +1,6 @@
 \section{Results}
 
-The experiment results are presented as a chart\ref{fig:Results} containing the amount of 
+The experiment results are presented as a chart (Figure \ref{fig:Results}) containing the amount of 
 points each agent was able to get while playing against the other agents. The agents are
 RandomAgent, GreedyAgent, RLAgent.
 
@@ -10,7 +10,7 @@ RandomAgent, GreedyAgent, RLAgent.
 	\label{fig:Results}
 \end{figure}
 
-The above mentioned results show that the engine's performance issues heavily
+The above-mentioned results show that the engine's performance issues heavily
 impacted the ability of the agent based on reinforcement learning to learn the game.
 Based on this results team decided the next steps should be to improve the engine's
 throughput as to increase the learning rate of the agent.


### PR DESCRIPTION
Textidote report BEFORE:
https://refined-github-html-preview.kidonng.workers.dev/YetAnotherSpieskowcy/Carcassonne-Documentation/raw/refs/heads/reports/report-before.html

Textidote report AFTER:
https://refined-github-html-preview.kidonng.workers.dev/YetAnotherSpieskowcy/Carcassonne-Documentation/raw/refs/heads/reports/report-after.html

Other changes:
- reordered bibliography according to order of refs
- removed placeholder bibliography items